### PR TITLE
Add audio feature loading and training safeguards

### DIFF
--- a/gazelle/dataloader.py
+++ b/gazelle/dataloader.py
@@ -117,11 +117,41 @@ class GazeDataset(torch.utils.data.dataset.Dataset):
 
         img = self.transform(img)
 
+        audio = None
+        if self.audio_roots:
+            rel_key = rel_img_path
+            rel_audio_paths = None
+            if self.audio_map and rel_key in self.audio_map:
+                rel_audio_paths = self.audio_map[rel_key]
+                if not isinstance(rel_audio_paths, (list, tuple)):
+                    rel_audio_paths = [rel_audio_paths]
+            else:
+                base = os.path.splitext(rel_key)[0] if rel_key else None
+                if base is not None:
+                    rel_audio_paths = [base + ".npy"] * len(self.audio_roots)
+
+            if rel_audio_paths and len(rel_audio_paths) == len(self.audio_roots):
+                feats = []
+                for root, dim, rel_a in zip(self.audio_roots, self.audio_dims, rel_audio_paths):
+                    a_path = os.path.join(root, rel_a)
+                    if os.path.exists(a_path):
+                        feat = torch.from_numpy(np.load(a_path)).float()
+                    elif self.missing_audio == "zeros":
+                        feat = torch.zeros(dim, dtype=torch.float32)
+                    else:
+                        feat = None
+                    if feat is None:
+                        feats = None
+                        break
+                    feats.append(feat)
+                if feats is not None:
+                    audio = torch.cat(feats, dim=0)
+
         if self.split == "train":
             heatmap = utils.get_heatmap(gazex_norm[0], gazey_norm[0], 64, 64)
-            return img, bbox_norm, gazex_norm, gazey_norm, torch.tensor(inout), height, width, heatmap
+            return img, bbox_norm, gazex_norm, gazey_norm, torch.tensor(inout), height, width, heatmap, audio
         else:
-            return img, bbox_norm, gazex_norm, gazey_norm, torch.tensor(inout), height, width
+            return img, bbox_norm, gazex_norm, gazey_norm, torch.tensor(inout), height, width, audio
 
     def __len__(self):
         return len(self.data_idxs)
@@ -129,7 +159,13 @@ class GazeDataset(torch.utils.data.dataset.Dataset):
 
 def collate_fn(batch):
     transposed = list(zip(*batch))
-    return tuple(
-        torch.stack(items) if isinstance(items[0], torch.Tensor) else list(items)
-        for items in transposed
-    )
+    collated = []
+    for items in transposed:
+        first = items[0]
+        if isinstance(first, torch.Tensor):
+            collated.append(torch.stack(items))
+        elif first is None:
+            collated.append(None)
+        else:
+            collated.append(list(items))
+    return tuple(collated)

--- a/gazelle/model.py
+++ b/gazelle/model.py
@@ -74,7 +74,7 @@ class GazeLLE(nn.Module):
         self.use_audio = use_audio
         self.audio_dim = audio_dim
         if self.use_audio:
-            self.audio_alpha = nn.Parameter(torch.zeros(1)) 
+            self.audio_alpha = nn.Parameter(torch.full((1,), 0.1))
             self.audio_norm = nn.LayerNorm(self.audio_dim)
             self.audio_fc = nn.Linear(self.audio_dim, self.dim)
             self.audio_drop = nn.Dropout(p=fusion_dropout)

--- a/scripts/train_audio.py
+++ b/scripts/train_audio.py
@@ -28,7 +28,8 @@ parser.add_argument('--image_root', type=str, default=None)
 parser.add_argument('--use_audio', action='store_true')
 parser.add_argument('--audio_roots', type=str, nargs='+', default=None)
 parser.add_argument('--audio_dims', type=int, nargs='+', default=None)
-parser.add_argument('--reg_lambda', type=float, default=1e-4)
+parser.add_argument('--reg_lambda', type=float, default=1e-5)
+parser.add_argument('--strict_load', action='store_true', help='Abort if checkpoint keys mismatch when set')
 
 # 视觉-only ckpt（来自数据集 A）
 parser.add_argument('--resume_ckpt', type=str, default=None, help='Path to visual-only ckpt from dataset A')
@@ -68,6 +69,8 @@ def main():
     os.makedirs(exp_dir, exist_ok=True)
 
     total_audio_dim = sum(args.audio_dims) if args.use_audio and args.audio_dims else 0
+    if args.use_audio and total_audio_dim == 0:
+        raise ValueError('--use_audio requires valid --audio_dims')
     model, transform = get_gazelle_model(args.model, use_audio=args.use_audio, audio_dim=total_audio_dim)
     model.cuda()
 
@@ -79,6 +82,14 @@ def main():
         missing, unexpected = model.load_state_dict(state, strict=False)
         print(f"   missing keys: {missing}")
         print(f"   unexpected keys: {unexpected}")
+        if args.strict_load and (len(missing) > 0 or len(unexpected) > 0):
+            raise RuntimeError('Checkpoint incompatible with model')
+        if 'linear.weight' in state:
+            w = state['linear.weight']
+            try:
+                print(f"   loaded linear.weight mean: {w.float().mean().item():.6f}")
+            except Exception:
+                pass
     else:
         print("\nℹ️ No --resume_ckpt provided (or file not found); training without loading A weights.")
 
@@ -97,6 +108,8 @@ def main():
     # DataLoaders
     train_dataset = GazeDataset('gazefollow', args.data_path, 'train', transform,
                                 image_root=args.image_root, audio_roots=args.audio_roots, audio_dims=args.audio_dims)
+    if args.use_audio and train_dataset.total_audio_dim == 0:
+        raise ValueError('Dataset provides no audio features but --use_audio is set')
     train_dl = torch.utils.data.DataLoader(train_dataset, batch_size=args.batch_size, shuffle=True,
                                            collate_fn=collate_fn, num_workers=args.n_workers)
 
@@ -130,6 +143,8 @@ def main():
             # 关键：将 bboxes 规整为 list[list[4]]
             safe_bboxes = _ensure_bbox_list_of_lists(bboxes)
             input_dict = {"images": imgs.cuda(), "bboxes": safe_bboxes}
+            if args.use_audio and audio is None:
+                raise RuntimeError('use_audio=True but audio features missing in batch')
             if args.use_audio and audio is not None:
                 input_dict["audio"] = audio.cuda(non_blocking=True)
 
@@ -170,6 +185,8 @@ def main():
 
                 safe_bboxes = _ensure_bbox_list_of_lists(bboxes)
                 input_dict = {"images": imgs.cuda(), "bboxes": safe_bboxes}
+                if args.use_audio and audio is None:
+                    raise RuntimeError('use_audio=True but audio features missing in eval batch')
                 if args.use_audio and audio is not None:
                     input_dict["audio"] = audio.cuda(non_blocking=True)
 


### PR DESCRIPTION
## Summary
- Load and return audio features in `GazeDataset`; collate function now handles optional audio tensors
- Initialize `audio_alpha` with a positive value to encourage audio fusion
- Add strict checkpoint loading and audio presence validation in `train_audio.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b60deb878c832489191b92942e0b6b